### PR TITLE
Add integration with turnitin/plagiabot/EranBot

### DIFF
--- a/app.py
+++ b/app.py
@@ -103,7 +103,8 @@ def index():
     update_sites()
     query = do_check()
     return render_template(
-        "index.mako", notice=notice, query=query, result=query.result)
+        "index.mako", notice=notice, query=query, result=query.result,
+        turnitin_result=query.turnitin_result)
 
 @app.route("/settings", methods=["GET", "POST"])
 @catch_errors

--- a/copyvios/checker.py
+++ b/copyvios/checker.py
@@ -11,6 +11,7 @@ from earwigbot.wiki.copyvios.result import CopyvioSource, CopyvioCheckResult
 
 from .misc import Query, get_db
 from .sites import get_site
+from .turnitin import search_turnitin
 
 __all__ = ["do_check", "T_POSSIBLE", "T_SUSPECT"]
 
@@ -63,9 +64,16 @@ def _get_results(query, follow=True):
         conn = get_db()
         use_engine = 0 if query.use_engine in ("0", "false") else 1
         use_links = 0 if query.use_links in ("0", "false") else 1
+        use_turnitin = 0 if query.turnitin in ("0", "false") else 1
         if not use_engine and not use_links:
             query.error = "no search method"
             return
+
+        # Handle the turnitin check
+        if use_turnitin:
+            query.turnitin_result = search_turnitin(query.title, query.lang)
+
+        # Handle the copyvio check
         mode = "{0}:{1}:".format(use_engine, use_links)
         if not _coerce_bool(query.nocache):
             query.result = _get_cached_results(

--- a/copyvios/misc.py
+++ b/copyvios/misc.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8  -*-
 
+import datetime
 from os.path import expanduser
 
 from flask import g, request
@@ -63,6 +64,9 @@ def httpsfix(context, url):
     if url.startswith("http://"):
         url = url[len("http:"):]
     return url
+
+def parse_wiki_timestamp(timestamp):
+    return datetime.datetime.strptime(timestamp, '%Y%m%d%H%M%S')
 
 def urlstrip(context, url):
     if url.startswith("http://"):

--- a/copyvios/turnitin.py
+++ b/copyvios/turnitin.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""TODO: Docstrings, tests?, documentation of input/output formats (esp. nested data structures woe)"""
+
+from ast import literal_eval
+import re
+
+import requests
+
+__all__ = ['search_turnitin', 'TURNITIN_API_ENDPOINT']
+
+TURNITIN_API_ENDPOINT = 'http://tools.wmflabs.org/eranbot/plagiabot/api.py'
+
+def search_turnitin(page_title, lang):
+    """ returns a list of tuples, one per report, each containing report id and data from the report"""
+    turnitin_data = _parse_reports(_make_api_request('The quick brown fox jumps over the lazy dog', lang))
+    turnitin_result = TurnitinResult(turnitin_data)
+    return turnitin_result
+
+def _make_api_request(page_title, lang):
+    stripped_page_title = page_title.replace(' ', '_')
+    api_parameters = {'action': 'suspected_diffs',
+                      'page_title': stripped_page_title,
+                      'lang': lang,
+                      'report': 1}
+
+    result = requests.get(TURNITIN_API_ENDPOINT, params=api_parameters)
+    parsed_result = literal_eval(result.text)  # should be ok with encoding, content-type utf-8
+    return parsed_result
+
+def _parse_reports(turnitin_api_result):
+    reports_data = []
+    for item in turnitin_api_result:
+        reports_data.append(_regex_magic(item['report']))
+    return reports_data
+
+def _regex_magic(report):
+    # ~magic~
+    report_id_pattern = re.compile(r'\?rid=(\d*)')
+    report_id = report_id_pattern.search(report).groups()[0]
+
+    extract_info_pattern = re.compile(r'\n\* \w\s+(\d*)\% (\d*) words at \[(.*?) ')
+    results = extract_info_pattern.findall(report)
+
+    return (report_id, results)
+
+class TurnitinResult:
+    def __init__(self, turnitin_data):
+        self.reports = []
+        for item in turnitin_data:
+            report = TurnitinReport(item)
+            self.reports.append(report)
+
+    def __repr__(self):
+        return str(self.__dict__)
+
+class TurnitinReport:
+    def __init__(self, data):
+        self.reportid = data[0]
+
+        self.sources = []
+        for item in data[1]:
+            source = {'percent': item[0],
+                      'words': item[1],
+                      'url': item[2]}
+            self.sources.append(source)
+
+    def __repr__(self):
+        return str(self.__dict__)

--- a/static/style.css
+++ b/static/style.css
@@ -65,7 +65,7 @@ div#info-box {
 
 div#turnitin-container {
     padding: 5px 10px;
-    margin: 15px 10px 10px 5px;
+    margin: 15px 5px 10px 5px;
 }
 
 div#turnitin-title {

--- a/static/style.css
+++ b/static/style.css
@@ -63,6 +63,17 @@ div#info-box {
     margin: 10px 5px;
 }
 
+div#turnitin-container {
+    padding: 5px 10px;
+    margin: 15px 10px 10px 5px;
+}
+
+div#turnitin-title {
+    margin-bottom: -5px;
+    text-align: center;
+    font-weight: bold;
+}
+
 div#cv-result {
     padding: 5px;
     margin: 10px 5px;

--- a/templates/index.mako
+++ b/templates/index.mako
@@ -172,10 +172,8 @@
                 <p>Turnitin (through <a href="https://en.wikipedia.org/wiki/User:EranBot">EranBot</a>) found revisions that may have been plagiarized. Please review them.</p>
 
                 <table id="turnitin-table"><tbody>
-                ## TODO: make this prettier/tabular
                 %for report in turnitin_result.reports:
-                    <tr><td><a href="https://tools.wmflabs.org/eranbot/ithenticate.py?rid=${report.reportid}">Turnitin report ${report.reportid} for text added in revision ${loop.index}</a>
-## TODO: Rework this to something like: [Turnitin report](link) for [revision at timestamp](diff link). Requires API-result-parsing/TurnitinReport changes. Shouldn't be too bad. Reason: needs to make it clear that Turnitin is looking at individual revisions; current report does not.
+                    <tr><td id="turnitin-table-cell"><a href="https://tools.wmflabs.org/eranbot/ithenticate.py?rid=${report.reportid}">Turnitin report ${report.reportid}</a> for text added <a href="https://${query.lang}.wikipedia.org/w/index.php?title=${query.title}&diff=${report.diffid}"> at ${report.time_posted}</a>:
                     <ul>
                     % for source in report.sources:
                           <li> ${source['percent']}% of revision text (${source['words']} words) found at <a href="${source['url']}">${source['url']}</a></li>
@@ -183,7 +181,6 @@
                     </ul></td></tr>
                 %endfor
                 </tbody></table>
-
             % else:
                 <p>Turnitin (through <a href="https://en.wikipedia.org/wiki/User:EranBot">EranBot</a>) found no matching sources.</p>
             % endif

--- a/templates/index.mako
+++ b/templates/index.mako
@@ -115,7 +115,7 @@
                             <label for="cv-cb-links">Use&nbsp;links&nbsp;in&nbsp;page</label>
                             <input class="cv-search" type="hidden" name="use_links" value="0" />
                             <span style="white-space:nowrap"><input id="cv-cb-turnitin" class="cv-search" type="checkbox" name="turnitin" value="1" ${'checked="checked"' if (query.turnitin != "0") else ""}/>
-                            <label for="cv-cb-turnitin">Search&nbsp;Turnitin&nbsp;reports</label></span>
+                            <label for="cv-cb-turnitin">Use&nbsp;Turnitin&nbsp;database</label></span>
                         </td>
                     </tr>
                     <tr>

--- a/templates/index.mako
+++ b/templates/index.mako
@@ -150,6 +150,7 @@
         </tr>
     </table>
 </form>
+
 % if result:
     <div id="generation-time">
         Results
@@ -166,14 +167,14 @@
     </div>
 
     % if query.turnitin:
-        <div id="turnitin-result" class="${'red' if query.turnitin_result else 'green'}-box">
-            <p>Turnitin results (this should be centered like "checked sources")</p>
-            % if query.turnitin_result:
-                Turnitin (through <a href="https://en.wikipedia.org/wiki/User:EranBot">EranBot</a>) found revisions that may have been plagiarized. Please review them. (Does this need some sort of p tag or something?)
+        <div id="turnitin-container" class="${'red' if query.turnitin_result.reports else 'green'}-box">
+            <div id="turnitin-title">Turnitin Results</div>
+            % if query.turnitin_result.reports:
+                <p>Turnitin (through <a href="https://en.wikipedia.org/wiki/User:EranBot">EranBot</a>) found revisions that may have been plagiarized. Please review them.</p>
 
                 %for report in turnitin_result.reports:
                 <ul>
-                    <li><a href="https://tools.wmflabs.org/eranbot/ithenticate.py?rid=${report.reportid}">Turnitin report</a>
+                    <li><a href="https://tools.wmflabs.org/eranbot/ithenticate.py?rid=${report.reportid}">Turnitin report ${report.reportid}</a>
                     <ul>
                     % for source in report.sources:
                           <li> ${source['percent']}% of revision text (${source['words']} words) found at <a href="${source['url']}">${source['url']}</a></li>
@@ -181,10 +182,9 @@
                     </ul></li>
                 %endfor
                 </ul>
-                ${turnitin_result}
 
             % else:
-                Turnitin (through <a href="https://en.wikipedia.org/wiki/User:EranBot">EranBot</a>) found no matching sources.
+                <p>Turnitin (through <a href="https://en.wikipedia.org/wiki/User:EranBot">EranBot</a>) found no matching sources.</p>
             % endif
         </div>
     % endif

--- a/templates/index.mako
+++ b/templates/index.mako
@@ -114,9 +114,8 @@
                             <input id="cv-cb-links" class="cv-search" type="checkbox" name="use_links" value="1" ${'checked="checked"' if (query.use_links != "0") else ""} />
                             <label for="cv-cb-links">Use&nbsp;links&nbsp;in&nbsp;page</label>
                             <input class="cv-search" type="hidden" name="use_links" value="0" />
-                            <br>
-                            <input id="cv-cb-turnitin" class="cv-search" type="checkbox" name="turnitin" value="1" ${'checked="checked"' if (query.turnitin != "0") else ""}/>
-                            <label for="cv-cb-turnitin">Find&nbsp;reports&nbsp;through&nbsp;Turnitin</label>
+                            <span style="white-space:nowrap"><input id="cv-cb-turnitin" class="cv-search" type="checkbox" name="turnitin" value="1" ${'checked="checked"' if (query.turnitin != "0") else ""}/>
+                            <label for="cv-cb-turnitin">Search&nbsp;Turnitin&nbsp;reports</label></span>
                         </td>
                     </tr>
                     <tr>
@@ -172,16 +171,18 @@
             % if query.turnitin_result.reports:
                 <p>Turnitin (through <a href="https://en.wikipedia.org/wiki/User:EranBot">EranBot</a>) found revisions that may have been plagiarized. Please review them.</p>
 
+                <table id="turnitin-table"><tbody>
+                ## TODO: make this prettier/tabular
                 %for report in turnitin_result.reports:
-                <ul>
-                    <li><a href="https://tools.wmflabs.org/eranbot/ithenticate.py?rid=${report.reportid}">Turnitin report ${report.reportid}</a>
+                    <tr><td><a href="https://tools.wmflabs.org/eranbot/ithenticate.py?rid=${report.reportid}">Turnitin report ${report.reportid} for text added in revision ${loop.index}</a>
+## TODO: Rework this to something like: [Turnitin report](link) for [revision at timestamp](diff link). Requires API-result-parsing/TurnitinReport changes. Shouldn't be too bad. Reason: needs to make it clear that Turnitin is looking at individual revisions; current report does not.
                     <ul>
                     % for source in report.sources:
                           <li> ${source['percent']}% of revision text (${source['words']} words) found at <a href="${source['url']}">${source['url']}</a></li>
                     % endfor
-                    </ul></li>
+                    </ul></td></tr>
                 %endfor
-                </ul>
+                </tbody></table>
 
             % else:
                 <p>Turnitin (through <a href="https://en.wikipedia.org/wiki/User:EranBot">EranBot</a>) found no matching sources.</p>

--- a/templates/index.mako
+++ b/templates/index.mako
@@ -113,6 +113,10 @@
                             <input class="cv-search" type="hidden" name="use_links" value="0" />
                             <input id="cv-cb-links" class="cv-search" type="checkbox" name="use_links" value="1" ${'checked="checked"' if (query.use_links != "0") else ""} />
                             <label for="cv-cb-links">Use&nbsp;links&nbsp;in&nbsp;page</label>
+                            <input class="cv-search" type="hidden" name="use_links" value="0" />
+                            <br>
+                            <input id="cv-cb-turnitin" class="cv-search" type="checkbox" name="turnitin" value="1" ${'checked="checked"' if (query.turnitin != "0") else ""}/>
+                            <label for="cv-cb-turnitin">Find&nbsp;reports&nbsp;through&nbsp;Turnitin</label>
                         </td>
                     </tr>
                     <tr>
@@ -160,6 +164,31 @@
         % endif
         <a href="${request.script_root | h}?lang=${query.lang | h}&amp;project=${query.project | h}&amp;oldid=${query.oldid or query.page.lastrevid | h}&amp;action=${query.action | h}&amp;${"use_engine={0}&use_links={1}".format(int(query.use_engine not in ("0", "false")), int(query.use_links not in ("0", "false"))) if query.action == "search" else "" | h}${"url=" if query.action == "compare" else ""}${query.url if query.action == "compare" else "" | u}">Permalink.</a>
     </div>
+
+    % if query.turnitin:
+        <div id="turnitin-result" class="${'red' if query.turnitin_result else 'green'}-box">
+            <p>Turnitin results (this should be centered like "checked sources")</p>
+            % if query.turnitin_result:
+                Turnitin (through <a href="https://en.wikipedia.org/wiki/User:EranBot">EranBot</a>) found revisions that may have been plagiarized. Please review them. (Does this need some sort of p tag or something?)
+
+                %for report in turnitin_result.reports:
+                <ul>
+                    <li><a href="https://tools.wmflabs.org/eranbot/ithenticate.py?rid=${report.reportid}">Turnitin report</a>
+                    <ul>
+                    % for source in report.sources:
+                          <li> ${source['percent']}% of revision text (${source['words']} words) found at <a href="${source['url']}">${source['url']}</a></li>
+                    % endfor
+                    </ul></li>
+                %endfor
+                </ul>
+                ${turnitin_result}
+
+            % else:
+                Turnitin (through <a href="https://en.wikipedia.org/wiki/User:EranBot">EranBot</a>) found no matching sources.
+            % endif
+        </div>
+    % endif
+
     <div id="cv-result" class="${'red' if result.confidence >= T_SUSPECT else 'yellow' if result.confidence >= T_POSSIBLE else 'green'}-box">
         <table id="cv-result-head-table">
             <colgroup>


### PR DESCRIPTION
Bug: https://phabricator.wikimedia.org/T110144

* Add the copyvios/turnitin.py module to query the plagiabot API and parse the results
* Modify app.py and copyvios/checker.py to do the query and provide the results to the page template
* Add checkbox and results div to templates/index.mako and associated CSS styling

Useful test pages: 
* http://tools.wmflabs.org/eranbot/plagiabot/api.py?action=suspected_diffs&page_title=Over_the_Limit_%282012%29&report=1
* http://tools.wmflabs.org/eranbot/plagiabot/api.py?action=suspected_diffs&page_title=The_quick_brown_fox_jumps_over_the_lazy_dog&report=1&lang=en
* http://tools.wmflabs.org/eranbot/plagiabot/api.py?action=suspected_diffs&page_title=Rajesh_Khanna&report=1